### PR TITLE
Filter privacy ops

### DIFF
--- a/evaluation/kubernetes/apps/istio-system/istio/envoy-filter/go-filter.yaml
+++ b/evaluation/kubernetes/apps/istio-system/istio/envoy-filter/go-filter.yaml
@@ -32,6 +32,7 @@ spec:
               value:
                 presidio_url: http://presidio.prose-system.svc.cluster.local:3000/batchanalyze
                 zipkin_url: http://zipkin.prose-system.svc.cluster.local:9411/api/v2/spans
+                opa_enable: false
                 opa_config: |
                   services: 
                     bundle_server:
@@ -78,6 +79,7 @@ spec:
               value:
                 presidio_url: http://presidio.prose-system.svc.cluster.local:3000/batchanalyze
                 zipkin_url: http://zipkin.prose-system.svc.cluster.local:9411/api/v2/spans
+                opa_enable: false
                 opa_config: |
                   services: 
                     bundle_server:

--- a/evaluation/kubernetes/apps/istio-system/istio/envoy-filter/go-filter.yaml
+++ b/evaluation/kubernetes/apps/istio-system/istio/envoy-filter/go-filter.yaml
@@ -43,6 +43,7 @@ spec:
                         max_delay_seconds: 3600
                   decision_logs:
                     console: true
+                presidio_url: http://presidio.prose-system.svc.cluster.local:3000/batchanalyze
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -88,3 +89,4 @@ spec:
                         max_delay_seconds: 3600
                   decision_logs:
                     console: true
+                presidio_url: http://presidio.prose-system.svc.cluster.local:3000/batchanalyze

--- a/evaluation/kubernetes/apps/istio-system/istio/envoy-filter/go-filter.yaml
+++ b/evaluation/kubernetes/apps/istio-system/istio/envoy-filter/go-filter.yaml
@@ -30,6 +30,7 @@ spec:
             plugin_config:
               "@type": type.googleapis.com/xds.type.v3.TypedStruct
               value:
+                presidio_url: http://presidio.prose-system.svc.cluster.local:3000/batchanalyze
                 zipkin_url: http://zipkin.prose-system.svc.cluster.local:9411/api/v2/spans
                 opa_config: |
                   services: 
@@ -43,7 +44,6 @@ spec:
                         max_delay_seconds: 3600
                   decision_logs:
                     console: true
-                presidio_url: http://presidio.prose-system.svc.cluster.local:3000/batchanalyze
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -76,6 +76,7 @@ spec:
             plugin_config:
               "@type": type.googleapis.com/xds.type.v3.TypedStruct
               value:
+                presidio_url: http://presidio.prose-system.svc.cluster.local:3000/batchanalyze
                 zipkin_url: http://zipkin.prose-system.svc.cluster.local:9411/api/v2/spans
                 opa_config: |
                   services: 
@@ -89,4 +90,3 @@ spec:
                         max_delay_seconds: 3600
                   decision_logs:
                     console: true
-                presidio_url: http://presidio.prose-system.svc.cluster.local:3000/batchanalyze

--- a/evaluation/kubernetes/apps/istio-system/istio/envoy-filter/go-filter.yaml
+++ b/evaluation/kubernetes/apps/istio-system/istio/envoy-filter/go-filter.yaml
@@ -31,6 +31,18 @@ spec:
               "@type": type.googleapis.com/xds.type.v3.TypedStruct
               value:
                 zipkin_url: http://zipkin.prose-system.svc.cluster.local:9411/api/v2/spans
+                opa_config: |
+                  services: 
+                    bundle_server:
+                      url:  http://prose-server.prose-system.svc.cluster.local:8080
+                  bundles:
+                    default:
+                      resource: /bundle.tar.gz
+                      polling:
+                        min_delay_seconds: 120
+                        max_delay_seconds: 3600
+                  decision_logs:
+                    console: true
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -64,3 +76,15 @@ spec:
               "@type": type.googleapis.com/xds.type.v3.TypedStruct
               value:
                 zipkin_url: http://zipkin.prose-system.svc.cluster.local:9411/api/v2/spans
+                opa_config: |
+                  services: 
+                    bundle_server:
+                      url:  http://prose-server.prose-system.svc.cluster.local:8080
+                  bundles:
+                    default:
+                      resource: /bundle.tar.gz
+                      polling:
+                        min_delay_seconds: 120
+                        max_delay_seconds: 3600
+                  decision_logs:
+                    console: true

--- a/privacy-profile-composer/pkg/composer/grpc_client.go
+++ b/privacy-profile-composer/pkg/composer/grpc_client.go
@@ -1,31 +1,15 @@
-/*
- *
- * Copyright 2015 gRPC authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
-
 package composer
 
 import (
 	"context"
 	"flag"
+	"log"
+
 	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/emptypb"
-	"log"
+
 	pb "privacy-profile-composer/pkg/proto"
 )
 

--- a/privacy-profile-composer/pkg/envoyfilter/config.go
+++ b/privacy-profile-composer/pkg/envoyfilter/config.go
@@ -61,7 +61,7 @@ func (p *ConfigParser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler
 	} else if presidioUrl, ok := parsedStr.(string); !ok {
 		return nil, fmt.Errorf("presidio_url: expect string while got %T", presidioUrl)
 	} else {
-		conf.opaConfig = presidioUrl
+		conf.presidioUrl = presidioUrl
 	}
 	return conf, nil
 }

--- a/privacy-profile-composer/pkg/envoyfilter/config.go
+++ b/privacy-profile-composer/pkg/envoyfilter/config.go
@@ -83,6 +83,8 @@ func (p *ConfigParser) Merge(parent interface{}, child interface{}) interface{} 
 		newConfig.presidioUrl = childConfig.presidioUrl
 	}
 
+	newConfig.opaEnable = childConfig.opaEnable
+
 	return &newConfig
 }
 

--- a/privacy-profile-composer/pkg/envoyfilter/config.go
+++ b/privacy-profile-composer/pkg/envoyfilter/config.go
@@ -10,8 +10,8 @@ import (
 )
 
 type config struct {
-	zipkinUrl          string
-	opaBundleServerUrl string // http://prose-server.prose-system.svc.cluster.local:8080
+	zipkinUrl string
+	opaConfig string // http://prose-server.prose-system.svc.cluster.local:8080
 }
 
 type ConfigParser struct {
@@ -34,12 +34,14 @@ func (p *ConfigParser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler
 		conf.zipkinUrl = str
 	}
 
-	if parsedStr, ok := configStruct["opa_bundle_server_url"]; !ok {
-		return nil, errors.New("missing opa_bundle_server_url")
-	} else if opaBundleServerUrl, ok := parsedStr.(string); !ok {
-		return nil, fmt.Errorf("opa_bundle_server_url: expect string while got %T", opaBundleServerUrl)
+	if parsedStr, ok := configStruct["opa_config"]; !ok {
+		return nil, errors.New("missing opa_config: expect a YAML inline string, " +
+			"as in this example: https://www.openpolicyagent.org/docs/latest/configuration/#example")
+	} else if opaConfig, ok := parsedStr.(string); !ok {
+		return nil, fmt.Errorf("opa_config: expect YAML inline string (for OPA config, as "+
+			"at https://www.openpolicyagent.org/docs/latest/configuration/#example) while got %T", opaConfig)
 	} else {
-		conf.opaBundleServerUrl = opaBundleServerUrl
+		conf.opaConfig = opaConfig
 	}
 	return conf, nil
 }
@@ -55,8 +57,8 @@ func (p *ConfigParser) Merge(parent interface{}, child interface{}) interface{} 
 		newConfig.zipkinUrl = childConfig.zipkinUrl
 	}
 
-	if childConfig.opaBundleServerUrl != "" {
-		newConfig.opaBundleServerUrl = childConfig.opaBundleServerUrl
+	if childConfig.opaConfig != "" {
+		newConfig.opaConfig = childConfig.opaConfig
 	}
 
 	return &newConfig

--- a/privacy-profile-composer/pkg/envoyfilter/config.go
+++ b/privacy-profile-composer/pkg/envoyfilter/config.go
@@ -36,14 +36,12 @@ func (p *ConfigParser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler
 		conf.zipkinUrl = str
 	}
 
-	if val, ok := configStruct["opa_enable"]; ok {
-		if opaEnable, ok := val.(bool); !ok {
-			return nil, fmt.Errorf("opa_enable: expect bool while got %T", opaEnable)
-		} else {
-			conf.opaEnable = opaEnable
-		}
-	} else {
+	if val, ok := configStruct["opa_enable"]; !ok {
 		conf.opaEnable = true
+	} else if opaEnable, ok := val.(bool); !ok {
+		return nil, fmt.Errorf("opa_enable: expect bool while got %T", opaEnable)
+	} else {
+		conf.opaEnable = opaEnable
 	}
 
 	// opa_config should be a YAML inline string,

--- a/privacy-profile-composer/pkg/envoyfilter/config.go
+++ b/privacy-profile-composer/pkg/envoyfilter/config.go
@@ -10,7 +10,8 @@ import (
 )
 
 type config struct {
-	zipkinUrl string
+	zipkinUrl          string
+	opaBundleServerUrl string // http://prose-server.prose-system.svc.cluster.local:8080
 }
 
 type ConfigParser struct {
@@ -33,6 +34,13 @@ func (p *ConfigParser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler
 		conf.zipkinUrl = str
 	}
 
+	if parsedStr, ok := configStruct["opa_bundle_server_url"]; !ok {
+		return nil, errors.New("missing opa_bundle_server_url")
+	} else if opaBundleServerUrl, ok := parsedStr.(string); !ok {
+		return nil, fmt.Errorf("opa_bundle_server_url: expect string while got %T", opaBundleServerUrl)
+	} else {
+		conf.opaBundleServerUrl = opaBundleServerUrl
+	}
 	return conf, nil
 }
 
@@ -45,6 +53,10 @@ func (p *ConfigParser) Merge(parent interface{}, child interface{}) interface{} 
 
 	if childConfig.zipkinUrl != "" {
 		newConfig.zipkinUrl = childConfig.zipkinUrl
+	}
+
+	if childConfig.opaBundleServerUrl != "" {
+		newConfig.opaBundleServerUrl = childConfig.opaBundleServerUrl
 	}
 
 	return &newConfig

--- a/privacy-profile-composer/pkg/envoyfilter/config.go
+++ b/privacy-profile-composer/pkg/envoyfilter/config.go
@@ -28,7 +28,7 @@ func (p *ConfigParser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler
 	if zipkinUrl, ok := configStruct["zipkin_url"]; !ok {
 		return nil, errors.New("missing zipkin_url")
 	} else if str, ok := zipkinUrl.(string); !ok {
-		return nil, fmt.Errorf("prefix_localreply_body: expect string while got %T", zipkinUrl)
+		return nil, fmt.Errorf("zipkin_url: expect string while got %T", zipkinUrl)
 	} else {
 		conf.zipkinUrl = str
 	}

--- a/privacy-profile-composer/pkg/envoyfilter/config.go
+++ b/privacy-profile-composer/pkg/envoyfilter/config.go
@@ -11,6 +11,7 @@ import (
 
 type config struct {
 	zipkinUrl   string
+	opaEnable   bool
 	opaConfig   string
 	presidioUrl string
 }
@@ -33,6 +34,16 @@ func (p *ConfigParser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler
 		return nil, fmt.Errorf("zipkin_url: expect string while got %T", zipkinUrl)
 	} else {
 		conf.zipkinUrl = str
+	}
+
+	if val, ok := configStruct["opa_enable"]; ok {
+		if opaEnable, ok := val.(bool); !ok {
+			return nil, fmt.Errorf("opa_enable: expect bool while got %T", opaEnable)
+		} else {
+			conf.opaEnable = opaEnable
+		}
+	} else {
+		conf.opaEnable = true
 	}
 
 	// opa_config should be a YAML inline string,

--- a/privacy-profile-composer/pkg/envoyfilter/inbound_filter.go
+++ b/privacy-profile-composer/pkg/envoyfilter/inbound_filter.go
@@ -14,19 +14,6 @@ import (
 	"privacy-profile-composer/pkg/envoyfilter/internal/common"
 )
 
-type inboundFilter struct {
-	api.PassThroughStreamFilter
-
-	callbacks api.FilterCallbackHandler
-	config    *config
-
-	parentSpanContext model.SpanContext
-	headerMetadata    common.HeaderMetadata
-	piiTypes          string
-	tracer            *common.ZipkinTracer
-	opa               *sdk.OPA
-}
-
 func NewInboundFilter(callbacks api.FilterCallbackHandler, config *config) api.StreamFilter {
 	tracer, err := common.NewZipkinTracer(config.zipkinUrl)
 	if err != nil {
@@ -46,6 +33,20 @@ func NewInboundFilter(callbacks api.FilterCallbackHandler, config *config) api.S
 		return &inboundFilter{callbacks: callbacks, config: config, tracer: tracer, opa: opaObj}
 	}
 	return &inboundFilter{callbacks: callbacks, config: config, tracer: tracer}
+}
+
+type inboundFilter struct {
+	api.PassThroughStreamFilter
+
+	callbacks api.FilterCallbackHandler
+	config    *config
+	tracer    *common.ZipkinTracer
+	opa       *sdk.OPA
+
+	// Runtime state of the filter
+	parentSpanContext model.SpanContext
+	headerMetadata    common.HeaderMetadata
+	piiTypes          string
 }
 
 // Callbacks which are called in request path

--- a/privacy-profile-composer/pkg/envoyfilter/inbound_filter.go
+++ b/privacy-profile-composer/pkg/envoyfilter/inbound_filter.go
@@ -84,7 +84,7 @@ func (f *inboundFilter) DecodeData(buffer api.BufferInstance, endStream bool) ap
 	log.Println("  <<About to forward", buffer.Len(), "bytes of data to service>>")
 
 	var jsonBody []byte
-	var err error
+
 	if f.headerMetadata.ContentType == nil {
 		log.Println("ContentType header is not set. Cannot analyze body")
 		return api.Continue
@@ -107,6 +107,7 @@ func (f *inboundFilter) DecodeData(buffer api.BufferInstance, endStream bool) ap
 		return api.Continue
 	}
 
+	var err error
 	if f.piiTypes, err = common.PiiAnalysis(f.config.presidioUrl, f.headerMetadata.SvcName, jsonBody); err != nil {
 		log.Println(err)
 		return api.Continue

--- a/privacy-profile-composer/pkg/envoyfilter/inbound_filter.go
+++ b/privacy-profile-composer/pkg/envoyfilter/inbound_filter.go
@@ -5,10 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
-	"fmt"
-	"io"
 	"log"
-	"net/http"
 	"net/url"
 
 	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
@@ -129,56 +126,6 @@ func sendComposedProfile(fqdn string, purpose string, piiTypes []string, thirdPa
 	return api.Continue
 }
 
-func piiAnalysis(svcName string, bufferBytes []byte) (string, error) {
-	var jsonBody = `{
-			"key_F": {
-				"key_a1": "My phone number is 212-121-1424"
-			},
-			"URL": "www.abc.com",
-			"key_c": 3,
-			"names": ["James Bond", "Clark Kent", "Hakeem Olajuwon", "No name here!"],
-			"address": "123 Alpha Beta, Waterloo ON N2L3G1, Canada",
-			"DOB": "01-01-1989",
-			"gender": "Female",
-			"race": "Asian",
-			"language": "English"
-		}`
-
-	svcNameBuf, err := json.Marshal(svcName)
-	if err != nil {
-		return "", fmt.Errorf("could not marshal service name string into a valid JSON string: %w", err)
-	}
-
-	// TODO replace jsonBody with bufferBytes input arg
-	msgString := `{"json_to_analyze":` + jsonBody + `,"derive_purpose":` + string(svcNameBuf) + `}`
-
-	resp, err := http.Post("http://presidio.prose-system.svc.cluster.local:3000/batchanalyze", "application/json", bytes.NewBufferString(msgString))
-	if err != nil {
-		return "", fmt.Errorf("presidio post error: %w", err)
-	}
-
-	log.Printf("presidio responded '%v', content-length is %v bytes\n", resp.Status, resp.ContentLength)
-
-	jsonResp, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("could not read Presidio response, %w", err)
-	}
-
-	err = resp.Body.Close()
-	if err != nil {
-		return "", fmt.Errorf("could not close presidio response body, %w", err)
-	}
-
-	log.Println("presidio response headers:")
-	for key, value := range resp.Header {
-		log.Printf("  \"%v\": %v\n", key, value)
-	}
-	log.Println("presidio response body:")
-	log.Printf("%v\n", string(jsonResp))
-
-	return string(jsonResp), nil
-}
-
 func (f *inboundFilter) DecodeData(buffer api.BufferInstance, endStream bool) api.StatusType {
 	log.Println(">>> DECODE DATA")
 	log.Println("  <<About to forward", buffer.Len(), "bytes of data to service>>")
@@ -213,7 +160,7 @@ func (f *inboundFilter) DecodeData(buffer api.BufferInstance, endStream bool) ap
 	}
 
 	var err error
-	if f.piiTypes, err = piiAnalysis(f.headerMetadata.SvcName, jsonBody); err != nil {
+	if f.piiTypes, err = common.PiiAnalysis(f.config.presidioUrl, f.headerMetadata.SvcName, jsonBody); err != nil {
 		log.Println(err)
 	}
 

--- a/privacy-profile-composer/pkg/envoyfilter/internal/common/pii_analysis.go
+++ b/privacy-profile-composer/pkg/envoyfilter/internal/common/pii_analysis.go
@@ -1,0 +1,60 @@
+package common
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+func PiiAnalysis(presidioSvcURL string, svcName string, bufferBytes []byte) (string, error) {
+	var jsonBody = `{
+			"key_F": {
+				"key_a1": "My phone number is 212-121-1424"
+			},
+			"URL": "www.abc.com",
+			"key_c": 3,
+			"names": ["James Bond", "Clark Kent", "Hakeem Olajuwon", "No name here!"],
+			"address": "123 Alpha Beta, Waterloo ON N2L3G1, Canada",
+			"DOB": "01-01-1989",
+			"gender": "Female",
+			"race": "Asian",
+			"language": "English"
+		}`
+
+	svcNameBuf, err := json.Marshal(svcName)
+	if err != nil {
+		return "", fmt.Errorf("could not marshal service name string into a valid JSON string: %w", err)
+	}
+
+	// TODO replace jsonBody with bufferBytes input arg
+	msgString := `{"json_to_analyze":` + jsonBody + `,"derive_purpose":` + string(svcNameBuf) + `}`
+
+	resp, err := http.Post(presidioSvcURL, "application/json", bytes.NewBufferString(msgString))
+	if err != nil {
+		return "", fmt.Errorf("presidio post error: %w", err)
+	}
+
+	log.Printf("presidio responded '%v', content-length is %v bytes\n", resp.Status, resp.ContentLength)
+
+	jsonResp, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("could not read Presidio response, %w", err)
+	}
+
+	err = resp.Body.Close()
+	if err != nil {
+		return "", fmt.Errorf("could not close presidio response body, %w", err)
+	}
+
+	log.Println("presidio response headers:")
+	for key, value := range resp.Header {
+		log.Printf("  \"%v\": %v\n", key, value)
+	}
+	log.Println("presidio response body:")
+	log.Printf("%v\n", string(jsonResp))
+
+	return string(jsonResp), nil
+}


### PR DESCRIPTION
- config.go: specified config options for Presidio URL, OPA Bundle Server URL and other OPA config parameters
- go-filter.yaml: added fields corresponding to the options that the golang filter expects (in config.go)
- inbound_filter.go: initialized objects once when the filter constructor is called and persisted the object, through Decode* and Encode* methods, until it is destroyed.