### PR TITLE
Filter privacy ops

### DIFF
--- a/evaluation/kubernetes/apps/test-sample-microservices/bookinfo/envoy-filter/golang-filter.yaml
+++ b/evaluation/kubernetes/apps/test-sample-microservices/bookinfo/envoy-filter/golang-filter.yaml
@@ -56,7 +56,7 @@ spec:
               value:
                 presidio_url: http://presidio.prose-system.svc.cluster.local:3000/batchanalyze
                 zipkin_url: http://zipkin.prose-system.svc.cluster.local:9411/api/v2/spans
-                opa_enable: false
+                opa_enforce: false
                 opa_config: |
                   services:
                     bundle_server:
@@ -127,7 +127,7 @@ spec:
               value:
                 presidio_url: http://presidio.prose-system.svc.cluster.local:3000/batchanalyze
                 zipkin_url: http://zipkin.prose-system.svc.cluster.local:9411/api/v2/spans
-                opa_enable: false
+                opa_enforce: false
                 opa_config: |
                   services:
                     bundle_server:

--- a/privacy-profile-composer/pkg/envoyfilter/common_constants.go
+++ b/privacy-profile-composer/pkg/envoyfilter/common_constants.go
@@ -4,7 +4,7 @@ package envoyfilter
 const (
 	PROSE_PRESIDIO_ERROR = "prose_presidio_error"
 	PROSE_PII_TYPES      = "prose_pii_types"
-	PROSE_OPA_STATUS     = "prose_opa_status"
+	PROSE_OPA_ENFORCE    = "prose_opa_enforce"
 	PROSE_OPA_ERROR      = "prose_opa_error"
 	PROSE_OPA_DECISION   = "prose_opa_decision"
 	PROSE_VIOLATION_TYPE = "prose_violation_type"

--- a/privacy-profile-composer/pkg/envoyfilter/common_constants.go
+++ b/privacy-profile-composer/pkg/envoyfilter/common_constants.go
@@ -1,0 +1,17 @@
+package envoyfilter
+
+// TODO: The tracing unit should use these as well.
+const (
+	PROSE_PRESIDIO_ERROR = "prose_presidio_error"
+	PROSE_PII_TYPES      = "prose_pii_types"
+	PROSE_OPA_STATUS     = "prose_opa_status"
+	PROSE_OPA_ERROR      = "prose_opa_error"
+	PROSE_OPA_DECISION   = "prose_opa_decision"
+	PROSE_VIOLATION_TYPE = "prose_violation_type"
+)
+
+const (
+	DataSharing          string = "DATA_SHARING"
+	PurposeOfUseDirect          = "PURPOSE_OF_USE_DIRECT"
+	PurposeOfUseIndirect        = "PURPOSE_OF_USE_INDIRECT"
+)

--- a/privacy-profile-composer/pkg/envoyfilter/common_constants.go
+++ b/privacy-profile-composer/pkg/envoyfilter/common_constants.go
@@ -1,6 +1,7 @@
 package envoyfilter
 
 // TODO: The tracing unit should use these as well.
+//  So these constants are shared between the data and control planes.
 const (
 	PROSE_PRESIDIO_ERROR = "prose_presidio_error"
 	PROSE_PII_TYPES      = "prose_pii_types"

--- a/privacy-profile-composer/pkg/envoyfilter/config.go
+++ b/privacy-profile-composer/pkg/envoyfilter/config.go
@@ -11,7 +11,7 @@ import (
 
 type config struct {
 	zipkinUrl   string
-	opaEnable   bool
+	opaEnforce  bool
 	opaConfig   string
 	presidioUrl string
 }
@@ -36,12 +36,13 @@ func (p *ConfigParser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler
 		conf.zipkinUrl = str
 	}
 
+	// decide whether to drop requests after a violation or not
 	if val, ok := configStruct["opa_enable"]; !ok {
-		conf.opaEnable = true
+		conf.opaEnforce = false // by default, don't drop requests (i.e. dev mode)
 	} else if opaEnable, ok := val.(bool); !ok {
 		return nil, fmt.Errorf("opa_enable: expect bool while got %T", opaEnable)
 	} else {
-		conf.opaEnable = opaEnable
+		conf.opaEnforce = opaEnable
 	}
 
 	// opa_config should be a YAML inline string,
@@ -83,7 +84,7 @@ func (p *ConfigParser) Merge(parent interface{}, child interface{}) interface{} 
 		newConfig.presidioUrl = childConfig.presidioUrl
 	}
 
-	newConfig.opaEnable = childConfig.opaEnable
+	newConfig.opaEnforce = childConfig.opaEnforce
 
 	return &newConfig
 }

--- a/privacy-profile-composer/pkg/envoyfilter/config_factory.go
+++ b/privacy-profile-composer/pkg/envoyfilter/config_factory.go
@@ -9,6 +9,6 @@ func ConfigFactory(c interface{}) api.StreamFilterFactory {
 	}
 
 	return func(callbacks api.FilterCallbackHandler) api.StreamFilter {
-		return NewInboundFilter(callbacks, conf)
+		return NewFilter(callbacks, conf)
 	}
 }

--- a/privacy-profile-composer/pkg/envoyfilter/config_factory.go
+++ b/privacy-profile-composer/pkg/envoyfilter/config_factory.go
@@ -9,6 +9,10 @@ func ConfigFactory(c interface{}) api.StreamFilterFactory {
 	}
 
 	return func(callbacks api.FilterCallbackHandler) api.StreamFilter {
-		return NewFilter(callbacks, conf)
+		filter, err := NewFilter(callbacks, conf)
+		if err != nil {
+			panic(err)
+		}
+		return filter
 	}
 }

--- a/privacy-profile-composer/pkg/envoyfilter/filter.go
+++ b/privacy-profile-composer/pkg/envoyfilter/filter.go
@@ -16,15 +16,15 @@ import (
 	"privacy-profile-composer/pkg/envoyfilter/internal/common"
 )
 
-func NewFilter(callbacks api.FilterCallbackHandler, config *config) api.StreamFilter {
+func NewFilter(callbacks api.FilterCallbackHandler, config *config) (api.StreamFilter, error) {
 	sidecarDirection, err := common.GetDirection(callbacks)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	tracer, err := common.NewZipkinTracer(config.zipkinUrl)
 	if err != nil {
-		log.Fatalf("unable to create tracer: %+v\n", err)
+		return nil, fmt.Errorf("unable to create tracer: %+v\n", err)
 	}
 
 	opaObj, err := sdk.New(context.Background(), sdk.Options{
@@ -33,7 +33,7 @@ func NewFilter(callbacks api.FilterCallbackHandler, config *config) api.StreamFi
 	})
 
 	if err != nil {
-		log.Fatalf("could not initialize an OPA object --- "+
+		return nil, fmt.Errorf("could not initialize an OPA object --- "+
 			"this means that the data plane cannot evaluate the target privacy policy ----- %+v\n", err)
 	}
 
@@ -43,7 +43,7 @@ func NewFilter(callbacks api.FilterCallbackHandler, config *config) api.StreamFi
 		tracer:           tracer,
 		sidecarDirection: sidecarDirection,
 		opa:              opaObj,
-	}
+	}, nil
 }
 
 type Filter struct {

--- a/privacy-profile-composer/pkg/envoyfilter/filter.go
+++ b/privacy-profile-composer/pkg/envoyfilter/filter.go
@@ -58,7 +58,6 @@ type Filter struct {
 	// Runtime state of the filter
 	parentSpanContext model.SpanContext
 	headerMetadata    common.HeaderMetadata
-	piiTypes          string
 }
 
 // Callbacks which are called in request path
@@ -116,9 +115,6 @@ func (f *Filter) DecodeData(buffer api.BufferInstance, endStream bool) api.Statu
 func (f *Filter) DecodeTrailers(trailers api.RequestTrailerMap) api.StatusType {
 	log.Println(">>> DECODE TRAILERS")
 	log.Printf("%+v", trailers)
-	if f.piiTypes != "" {
-		trailers.Add("x-prose-pii-types", f.piiTypes) // For OPA
-	}
 	return api.Continue
 }
 
@@ -194,7 +190,6 @@ func (f *Filter) runPresidioAndOPA(jsonBody []byte, isDecode bool) error {
 		span.Tag(PROSE_PRESIDIO_ERROR, fmt.Sprintf("%s", err))
 		return err
 	}
-	f.piiTypes = piiTypes
 	span.Tag(PROSE_PII_TYPES, piiTypes)
 
 	span.Tag(PROSE_OPA_ENFORCE, strconv.FormatBool(f.config.opaEnforce))

--- a/privacy-profile-composer/pkg/envoyfilter/filter.go
+++ b/privacy-profile-composer/pkg/envoyfilter/filter.go
@@ -195,7 +195,8 @@ func (f *Filter) runPresidioAndOPA(jsonBody []byte, isDecode bool) error {
 	span.Tag(PROSE_OPA_ENFORCE, strconv.FormatBool(f.config.opaEnforce))
 
 	// get the named policy decision for the specified input
-	if result, err := f.opa.Decision(context.Background(),
+	if result, err := f.opa.Decision(
+		context.Background(),
 		sdk.DecisionOptions{
 			Path: "/authz/allow",
 			// TODO: Pass in the purpose of use,
@@ -206,7 +207,9 @@ func (f *Filter) runPresidioAndOPA(jsonBody []byte, isDecode bool) error {
 			//  as simple.rego expects PII type & purpose to be passed as headers
 			//  (i.e. as if we had an OPA sidecar)
 			Input:  map[string]interface{}{"hello": "world"},
-			Tracer: topdown.NewBufferTracer()}); err != nil {
+			Tracer: topdown.NewBufferTracer(),
+		},
+	); err != nil {
 		errStr := fmt.Sprintf("had an error evaluating the policy: %s", err)
 		span.Tag(PROSE_OPA_ERROR, errStr)
 		return fmt.Errorf("%s\n", errStr)

--- a/privacy-profile-composer/pkg/envoyfilter/inbound_filter.go
+++ b/privacy-profile-composer/pkg/envoyfilter/inbound_filter.go
@@ -65,17 +65,6 @@ func (f *inboundFilter) DecodeHeaders(header api.RequestHeaderMap, endStream boo
 
 	common.LogDecodeHeaderData(header)
 
-	if f.config.opaEnable {
-		// get the named policy decision for the specified input
-		if result, err := f.opa.Decision(context.Background(), sdk.DecisionOptions{Path: "/authz/allow", Input: map[string]interface{}{"hello": "world"}}); err != nil {
-			log.Printf("had an error evaluating the policy: %s\n", err)
-		} else if decision, ok := result.Result.(bool); !ok || !decision {
-			log.Printf("result: descision: %v, ok: %v\n", decision, ok)
-		} else {
-			log.Printf("policy accepted the input data \n")
-		}
-	}
-
 	return api.Continue
 }
 
@@ -111,6 +100,17 @@ func (f *inboundFilter) DecodeData(buffer api.BufferInstance, endStream bool) ap
 	if f.piiTypes, err = common.PiiAnalysis(f.config.presidioUrl, f.headerMetadata.SvcName, jsonBody); err != nil {
 		log.Println(err)
 		return api.Continue
+	}
+
+	if f.config.opaEnable {
+		// get the named policy decision for the specified input
+		if result, err := f.opa.Decision(context.Background(), sdk.DecisionOptions{Path: "/authz/allow", Input: map[string]interface{}{"hello": "world"}}); err != nil {
+			log.Printf("had an error evaluating the policy: %s\n", err)
+		} else if decision, ok := result.Result.(bool); !ok || !decision {
+			log.Printf("result: descision: %v, ok: %v\n", decision, ok)
+		} else {
+			log.Printf("policy accepted the input data \n")
+		}
 	}
 
 	return api.Continue

--- a/privacy-profile-composer/pkg/envoyfilter/inbound_filter.go
+++ b/privacy-profile-composer/pkg/envoyfilter/inbound_filter.go
@@ -4,17 +4,23 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"log"
-	"net/url"
-
+	"fmt"
 	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
 	"github.com/open-policy-agent/opa/sdk"
 	"github.com/openzipkin/zipkin-go"
 	"github.com/openzipkin/zipkin-go/model"
+	"log"
+	"net/url"
 	"privacy-profile-composer/pkg/envoyfilter/internal/common"
+	"strconv"
 )
 
 func NewInboundFilter(callbacks api.FilterCallbackHandler, config *config) api.StreamFilter {
+	sidecarDirection, err := getDirection(callbacks)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	tracer, err := common.NewZipkinTracer(config.zipkinUrl)
 	if err != nil {
 		log.Fatalf("unable to create tracer: %+v\n", err)
@@ -30,24 +36,42 @@ func NewInboundFilter(callbacks api.FilterCallbackHandler, config *config) api.S
 			log.Fatalf("could not initialize an OPA object --- "+
 				"this means that the data plane cannot evaluate the target privacy policy ----- %+v\n", err)
 		}
-		return &inboundFilter{callbacks: callbacks, config: config, tracer: tracer, opa: opaObj}
+		return &inboundFilter{
+			callbacks:        callbacks,
+			config:           config,
+			tracer:           tracer,
+			sidecarDirection: sidecarDirection,
+			opa:              opaObj,
+		}
 	}
-	return &inboundFilter{callbacks: callbacks, config: config, tracer: tracer}
+	return &inboundFilter{
+		callbacks:        callbacks,
+		config:           config,
+		tracer:           tracer,
+		sidecarDirection: sidecarDirection}
 }
 
 type inboundFilter struct {
 	api.PassThroughStreamFilter
 
-	callbacks api.FilterCallbackHandler
-	config    *config
-	tracer    *common.ZipkinTracer
-	opa       *sdk.OPA
+	callbacks        api.FilterCallbackHandler
+	config           *config
+	tracer           *common.ZipkinTracer
+	opa              *sdk.OPA
+	sidecarDirection SidecarDirection
 
 	// Runtime state of the filter
 	parentSpanContext model.SpanContext
 	headerMetadata    common.HeaderMetadata
 	piiTypes          string
 }
+
+type SidecarDirection int
+
+const (
+	Inbound SidecarDirection = iota
+	Outbound
+)
 
 // Callbacks which are called in request path
 func (f *inboundFilter) DecodeHeaders(header api.RequestHeaderMap, endStream bool) api.StatusType {
@@ -167,4 +191,33 @@ func (f *inboundFilter) OnDestroy(reason api.DestroyReason) {
 	if f.config.opaEnable {
 		f.opa.Stop(context.Background())
 	}
+}
+
+func getDirection(callbacks api.FilterCallbackHandler) (SidecarDirection, error) {
+	directionEnum, err := callbacks.GetProperty("xds.listener_direction")
+	if err != nil {
+		return -1, fmt.Errorf("cannot determine sidecar direction as there is no xds.listener_direction key")
+	}
+	directionInt, err := strconv.Atoi(directionEnum)
+	if err != nil {
+		// check https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/base.proto#envoy-v3-api-enum-config-core-v3-trafficdirection
+		return -1, fmt.Errorf("envoy's xds.listener_direction key does not contain an integer " +
+			"check the Envoy docs for the range of values for this key")
+	}
+
+	if directionInt == 0 {
+		return -1, fmt.Errorf("envoy's xds.listener_direction key indicates that this sidecar is deployed as a gateway." +
+			"Prose does not need to be run in a gateway sidecar." +
+			"It will continue to get deployed in other sidecars that are configured as inbound or outbound sidecars")
+	}
+
+	if directionInt == 1 {
+		return Inbound, nil
+	}
+	if directionInt == 2 {
+		return Outbound, nil
+	}
+
+	return -1, fmt.Errorf("envoy's xds.listener_direction key contains an unsupported value for the direction enum: %d "+
+		"check the Envoy docs for the range of values for this key", directionInt)
 }

--- a/privacy-profile-composer/pkg/envoyfilter/internal/common/packet_processing.go
+++ b/privacy-profile-composer/pkg/envoyfilter/internal/common/packet_processing.go
@@ -1,8 +1,13 @@
 package common
 
 import (
-	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
+	"encoding/json"
+	"fmt"
 	"log"
+	"net/url"
+	"strconv"
+
+	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
 )
 
 const anyPurpose = "ANY"
@@ -20,6 +25,13 @@ type HeaderMetadata struct {
 	SvcName string
 	Purpose string
 }
+
+type SidecarDirection int
+
+const (
+	Inbound SidecarDirection = iota
+	Outbound
+)
 
 func LogDecodeHeaderData(header api.RequestHeaderMap) {
 	log.Printf("%v (%v) %v://%v%v\n", header.Method(), header.Protocol(), header.Scheme(), header.Host(), header.Path())
@@ -84,4 +96,56 @@ func ExtractHeaderData(header api.RequestHeaderMap) HeaderMetadata {
 	}
 
 	return metadata
+}
+
+func GetDirection(callbacks api.FilterCallbackHandler) (SidecarDirection, error) {
+	directionEnum, err := callbacks.GetProperty("xds.listener_direction")
+	if err != nil {
+		return -1, fmt.Errorf("cannot determine sidecar direction as there is no xds.listener_direction key")
+	}
+	directionInt, err := strconv.Atoi(directionEnum)
+	if err != nil {
+		// check https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/base.proto#envoy-v3-api-enum-config-core-v3-trafficdirection
+		return -1, fmt.Errorf("envoy's xds.listener_direction key does not contain an integer " +
+			"check the Envoy docs for the range of values for this key")
+	}
+
+	if directionInt == 0 {
+		return -1, fmt.Errorf("envoy's xds.listener_direction key indicates that this sidecar is deployed as a gateway." +
+			"Prose does not need to be run in a gateway sidecar." +
+			"It will continue to get deployed in other sidecars that are configured as inbound or outbound sidecars")
+	}
+
+	if directionInt == 1 {
+		return Inbound, nil
+	}
+	if directionInt == 2 {
+		return Outbound, nil
+	}
+
+	return -1, fmt.Errorf("envoy's xds.listener_direction key contains an unsupported value for the direction enum: %d "+
+		"check the Envoy docs for the range of values for this key", directionInt)
+}
+
+func GetJSONBody(headerMetadata HeaderMetadata, buffer api.BufferInstance) ([]byte, error) {
+	var jsonBody []byte
+
+	if headerMetadata.ContentType == nil {
+		return nil, fmt.Errorf("ContentType header is not set. Cannot analyze body")
+	} else if *headerMetadata.ContentType == "application/x-www-form-urlencoded" {
+		query, err := url.ParseQuery(buffer.String())
+		if err != nil {
+			return nil, fmt.Errorf("Failed to start decoding JSON data")
+		}
+		log.Println("  <<decoded x-www-form-urlencoded data: ", query)
+		jsonBody, err = json.Marshal(query)
+		if err != nil {
+			return nil, fmt.Errorf("Could not transform URL encoded data to JSON to pass to Presidio")
+		}
+	} else if *headerMetadata.ContentType == "application/json" {
+		jsonBody = buffer.Bytes()
+	} else {
+		return nil, fmt.Errorf("Cannot analyze a body with contentType '%s'\n", *headerMetadata.ContentType)
+	}
+	return jsonBody, nil
 }


### PR DESCRIPTION
- Added span tags for PII types, OPA decision status, Violation type.
- Added algorithm for encodeData and decodeData
- Renamed the `opa_enable` key for the filter to `opa_enforce`. Earlier, the OPA enable mode just decided whether to run OPA or not. Instead, we use it to decide whether to drop requests after a violation or not. Ideally, I want to avoid having two opa flags (one for whether to run OPA or not and another for whether to enforce its decision), as that can be confusing. So we always create the OPA object and evaluate the PII types etc against the policy. Note that we can set the bundle server to dispense an "allow all" policy in the development stage, before the privacy engineer has set a meaningful target policy.
- OPA Enforcement: If the `opa_enforce` key is set to true, actually drop the request. 

TODO: OPA is currently evaluating sample inputs. Tweak it to pass in the purpose of use, pii types and third parties. See TODO in `runPresidioAndOPA`. 
